### PR TITLE
[skip ci] Update master references for main branch

### DIFF
--- a/getting-started-guides/csp/gcp/spark-gpu/README.md
+++ b/getting-started-guides/csp/gcp/spark-gpu/README.md
@@ -93,11 +93,11 @@ described in the
 documentation. 
 
 See
-[the Mortgage example](https://github.com/rapidsai/spark-examples/tree/master/examples/apps/scala/src/main/scala/ai/rapids/spark/examples/mortgage)
+[the Mortgage example](https://github.com/rapidsai/spark-examples/tree/main/examples/apps/scala/src/main/scala/ai/rapids/spark/examples/mortgage)
 that demonstrates end to end XGBoost4j in spark including data pre-processing and model
 training with RAPIDS Spark GPU APIs. Additional examples
-[are available](https://github.com/rapidsai/spark-examples/tree/master/examples). See the
-[RAPIDS Spark GPU API documentation](https://github.com/rapidsai/spark-examples/tree/master/api-docs) for API details.
+[are available](https://github.com/rapidsai/spark-examples/tree/main/examples). See the
+[RAPIDS Spark GPU API documentation](https://github.com/rapidsai/spark-examples/tree/main/api-docs) for API details.
 
 To submit such a job run:
 

--- a/getting-started-guides/on-prem-cluster/kubernetes.md
+++ b/getting-started-guides/on-prem-cluster/kubernetes.md
@@ -38,7 +38,7 @@ export SPARK_DOCKER_IMAGE=<gpu spark docker image repo and name>
 export SPARK_DOCKER_TAG=<spark docker image tag>
 
 pushd ${SPARK_HOME}
-wget https://github.com/rapidsai/spark-examples/raw/master/Dockerfile
+wget https://github.com/rapidsai/spark-examples/raw/main/Dockerfile
 
 # Optionally install additional jars into ${SPARK_HOME}/jars/
 


### PR DESCRIPTION
This PR changes any 'master' references to 'main' in markdown files throughout the repo as part of the new 'master' to 'main' branch migration.